### PR TITLE
Add support for smallvec::SmallVec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  * Add new `cb58` feature to support injecting and verifying that checksum (by @Zondax)
  * Update `sha2` to 0.10 (by @madninja)
  * Tighten max-encoded length estimation to reduce overallocation of resizable buffers (by @mina86)
+ * Add optional support for encoding/decoding to `smallvec::SmallVec` (by @mina86)
 
 ## 0.4.0 - 2020-11-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "criterion",
  "rust-base58",
  "sha2",
+ "smallvec",
 ]
 
 [[package]]
@@ -653,6 +654,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "structopt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cb58 = ["sha2"]
 
 [dependencies]
 sha2 = { version = "0.10", optional = true, default-features = false }
+smallvec = { version = "1", optional = true }
 
 [dev_dependencies]
 criterion = "0.3"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -110,6 +110,22 @@ impl DecodeTarget for Vec<u8> {
     }
 }
 
+#[cfg(feature = "smallvec")]
+impl<A: smallvec::Array<Item = u8>> DecodeTarget for smallvec::SmallVec<A> {
+    /// Decodes data into a [`smallvec::SmallVec`].
+    fn decode_with(
+        &mut self,
+        max_len: usize,
+        f: impl for<'a> FnOnce(&'a mut [u8]) -> Result<usize>,
+    ) -> Result<usize> {
+        let original = self.len();
+        self.resize(original + max_len, 0);
+        let len = f(&mut self[original..])?;
+        self.truncate(original + len);
+        Ok(len)
+    }
+}
+
 impl DecodeTarget for [u8] {
     fn decode_with(
         &mut self,

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -7,6 +7,21 @@ use assert_matches::assert_matches;
 fn test_decode() {
     for &(val, s) in cases::TEST_CASES.iter() {
         assert_eq!(val.to_vec(), bs58::decode(s).into_vec().unwrap());
+
+        const PREFIX: &[u8] = &[0, 1, 2];
+
+        {
+            let mut vec = PREFIX.to_vec();
+            assert_eq!(Ok(val.len()), bs58::decode(s).into(&mut vec));
+            assert_eq!((PREFIX, val), vec.split_at(3));
+        }
+
+        #[cfg(feature = "smallvec")]
+        {
+            let mut vec = smallvec::SmallVec::<[u8; 36]>::from(PREFIX);
+            assert_eq!(Ok(val.len()), bs58::decode(s).into(&mut vec));
+            assert_eq!((PREFIX, val), vec.split_at(3));
+        }
     }
 }
 

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -29,6 +29,21 @@ fn test_encode() {
             }
             assert_eq!(&FILLER[(s.len() + 1)..], &bytes[(s.len() + 1)..]);
         }
+
+        const PREFIX: &[u8] = &[0, 1, 2];
+
+        {
+            let mut vec = PREFIX.to_vec();
+            assert_eq!(Ok(s.len()), bs58::encode(val).into(&mut vec));
+            assert_eq!((PREFIX, s.as_bytes()), vec.split_at(3));
+        }
+
+        #[cfg(feature = "smallvec")]
+        {
+            let mut vec = smallvec::SmallVec::<[u8; 36]>::from(PREFIX);
+            assert_eq!(Ok(s.len()), bs58::encode(val).into(&mut vec));
+            assert_eq!((PREFIX, s.as_bytes()), vec.split_at(3));
+        }
     }
 }
 


### PR DESCRIPTION
Introduce `smallvec` cargo feature which pulls in `smallvec` crate and
implements `EncodeTarget` and `DecodeTarget` for `smallvec::SmallVec`.
With that, it’s now possible to use encoder’s and decoder’s `into`
methods to write data into a smell vector.  This may be used to
prevent heap allocations for short data while properly handling larger
data.
